### PR TITLE
X509 Marshaling/Unmarshaling of keys and PEM files 

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -4,14 +4,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
 	"math/big"
 )
-
-// PrivateKeyBytesLength defines the length in bytes of a serialized private key
-const PrivateKeyBytesLength = 32
 
 // Signature is a type representing an ECDSA signature
 type Signature struct {
@@ -57,10 +51,6 @@ func (pubk *PublicKey) Verify(hash []byte, sig *Signature) bool {
 	return verified
 }
 
-// ---------------------------
-// exported utility functions
-// ---------------------------
-
 // GenerateKeyPair create a private/public key pair using an elliptic curve
 func GenerateKeyPair(curve elliptic.Curve) (*PrivateKey, *PublicKey, error) {
 	prvKey, err := ecdsa.GenerateKey(curve, rand.Reader)
@@ -77,101 +67,4 @@ func GenerateKeyPairP256() (*PrivateKey, *PublicKey, error) {
 		return nil, nil, err
 	}
 	return (*PrivateKey)(prvKey), (*PublicKey)(&prvKey.PublicKey), nil
-}
-
-// KeyPairFromBytes todo
-func KeyPairFromBytes(curve elliptic.Curve, pk []byte) (*PrivateKey, *PublicKey) {
-	x, y := curve.ScalarBaseMult(pk)
-	priv := &ecdsa.PrivateKey{
-		PublicKey: ecdsa.PublicKey{
-			Curve: curve,
-			X:     x,
-			Y:     y,
-		},
-		D: new(big.Int).SetBytes(pk),
-	}
-	return (*PrivateKey)(priv), (*PublicKey)(&priv.PublicKey)
-}
-
-// X509MarshalECPrivateKey marshals an EC private key into ASN.1, DER format. (wrapper around x509 in crypto pkg)
-func X509MarshalECPrivateKey(key *PrivateKey) ([]byte, error) {
-	x509Encoded, err := x509.MarshalECPrivateKey(key.ToECDSA())
-	if err != nil {
-		return nil, err
-	}
-	return x509Encoded, nil
-}
-
-// X509MarhsalECPublicKey serialises a public key to DER-encoded PKIX format. (wrapper around x509 in crypto pkg)
-func X509MarhsalECPublicKey(key *PublicKey) ([]byte, error) {
-	x509EncodePubKey, err := x509.MarshalPKIXPublicKey(key.ToECDSA())
-	if err != nil {
-		return nil, err
-	}
-	return x509EncodePubKey, nil
-}
-
-// X509UnmarshalECPrivateKey  parses an ASN.1 Elliptic Curve Private Key Structure (wrapper around x509 in crypto pkg)
-func X509UnmarshalECPrivateKey(der []byte) (*PrivateKey, error) {
-	key, err := x509.ParseECPrivateKey(der)
-	if err != nil {
-		return nil, err
-	}
-	return (*PrivateKey)(key), nil
-}
-
-// X509UnmarshalECPublicKey parses a DER encoded public key. (wrapper around x509 in crypto pkg)
-func X509UnmarshalECPublicKey(der []byte) (*PublicKey, error) {
-	key, err := x509.ParsePKIXPublicKey(der)
-	eckey := key.(*ecdsa.PublicKey)
-	if err != nil {
-		return nil, err
-	}
-	return (*PublicKey)(eckey), nil
-}
-
-// PemEncodePrivateKey returns the PEM encoding of key
-func PemEncodePrivateKey(key *PrivateKey) []byte {
-	x509encoded, err := X509MarshalECPrivateKey(key)
-	if err != nil {
-		return nil
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509encoded})
-}
-
-// PemEncodePublicKey returns the PEM encoding of key
-func PemEncodePublicKey(key *PublicKey) []byte {
-	x509encoded, err := X509MarhsalECPublicKey(key)
-	if err != nil {
-		return nil
-	}
-	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509encoded})
-}
-
-// PemDecodePrivateKey will find the next PEM formatted block (certificate, private key etc) in the input
-// If no PEM data is found, PrivateKey will be nil and an error will be returned
-func PemDecodePrivateKey(pemEncoded []byte) (*PrivateKey, error) {
-	block, _ := pem.Decode(pemEncoded)
-	if block == nil {
-		return nil, errors.New("Missing block data")
-	}
-	prvKey, err := X509UnmarshalECPrivateKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return prvKey, nil
-}
-
-// PemDecodePublicKey will find the next PEM formatted block (certificate, private key etc) in the input
-// If no PEM data is found, PublicKey will be nil and an error will be returned
-func PemDecodePublicKey(pemEncoded []byte) (*PublicKey, error) {
-	block, _ := pem.Decode(pemEncoded)
-	if block == nil {
-		return nil, errors.New("Missing block data")
-	}
-	pubKey, err := X509UnmarshalECPublicKey(block.Bytes)
-	if err != nil {
-		return nil, err
-	}
-	return pubKey, nil
 }

--- a/keys_test.go
+++ b/keys_test.go
@@ -1,7 +1,6 @@
 package crypto
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -103,40 +102,5 @@ func TestNonDeterministic(t *testing.T) {
 
 	if sig1.R == sig2.R && sig1.S == sig2.S {
 		t.Error("Expected : mismatch signatures, Got: matching signatures")
-	}
-}
-
-func TestX509MarshalingEllipticCurvesKeys(t *testing.T) {
-	prv, pub, err := GenerateKeyPairP256()
-	if err != nil {
-		t.Error("Failed to generate keys using P256 ellipitic curve", err)
-	}
-
-	x509Encodedpriv, err := X509MarshalECPrivateKey(prv)
-	if err != nil {
-		t.Error("Failed to marshal private key", err)
-	}
-
-	x509Encodedpub, err := X509MarhsalECPublicKey(pub)
-	if err != nil {
-		t.Error("failed to marshal public key", err)
-	}
-
-	privkey, err := X509UnmarshalECPrivateKey(x509Encodedpriv)
-	if err != nil {
-		t.Error("failed to unmarshal private key", err)
-	}
-
-	pubkey, err := X509UnmarshalECPublicKey(x509Encodedpub)
-	if err != nil {
-		t.Error("failed to unmarshal public key", err)
-	}
-
-	if !reflect.DeepEqual(prv, privkey) {
-		t.Error("Keys do not match after unmarshaling")
-	}
-
-	if !reflect.DeepEqual(pub, pubkey) {
-		t.Error("keys do not match after unmarshaling")
 	}
 }

--- a/pem.go
+++ b/pem.go
@@ -1,0 +1,92 @@
+package crypto
+
+import (
+	"encoding/pem"
+	"errors"
+	"io/ioutil"
+)
+
+// EncodePrivateKeyX509PEM returns the DER-encoded PEM encoding of the private key
+// returns PEM encoded bytes or nil if there is an error
+func EncodePrivateKeyX509PEM(prv *PrivateKey) []byte {
+	x509encoding, err := MarhsalPrivateKeyX509(prv)
+	if err != nil {
+		return nil
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: x509encoding})
+}
+
+// EncodePublicKeyX509PEM returns the DER-encoded PEM encoding of the public key
+// returns PEM encoded bytes or nil if there is an error
+func EncodePublicKeyX509PEM(pubk *PublicKey) []byte {
+	x509encoding, err := MarshaPublicKeyX509(pubk)
+	if err != nil {
+		return nil
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: x509encoding})
+}
+
+// DecodeX509PEM returns a pem block as bytes or nil if no data is found
+func DecodeX509PEM(pemEncoded []byte) ([]byte, error) {
+	block, _ := pem.Decode(pemEncoded)
+	if block == nil {
+		return nil, errors.New("Unable to decode PEM Block data")
+	}
+	return block.Bytes, nil
+}
+
+// PrivateKeyFromPEMFile reads a X509 PEM encoded private key from file
+// returns a private key or error
+func PrivateKeyFromPEMFile(fileName string) (*PrivateKey, error) {
+	content, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	der, err := DecodeX509PEM(content)
+	if err != nil {
+		return nil, err
+	}
+	prvk, err := UnmarshalX509PrivateKey(der)
+	if err != nil {
+		return nil, err
+	}
+	return prvk, nil
+}
+
+// PublicKeyFromPEMFile reads a X509 PEM encoded public key from file
+// returns a public key or error
+func PublicKeyFromPEMFile(fileName string) (*PublicKey, error) {
+	content, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return nil, err
+	}
+	der, err := DecodeX509PEM(content)
+	if err != nil {
+		return nil, err
+	}
+	pubk, err := UnmarshalPublicKeyX509(der)
+	if err != nil {
+		return nil, err
+	}
+	return pubk, nil
+}
+
+// PrivateKeyToPEMFile writes a X509 PEM encoded private key to a file
+func PrivateKeyToPEMFile(fileName string, privateKey *PrivateKey) error {
+	content := EncodePrivateKeyX509PEM(privateKey)
+	if content == nil {
+		return errors.New("Failed to encode private key")
+	}
+	err := ioutil.WriteFile(fileName, content, 0600)
+	return err
+}
+
+// PublicKeyToPEMFile writes a X509 PEM encoded public key to a file
+func PublicKeyToPEMFile(fileName string, publicKey *PublicKey) error {
+	content := EncodePublicKeyX509PEM(publicKey)
+	if content == nil {
+		return errors.New("Failed to encode private key")
+	}
+	err := ioutil.WriteFile(fileName, content, 0600)
+	return err
+}

--- a/pem_test.go
+++ b/pem_test.go
@@ -1,0 +1,51 @@
+package crypto
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPEMEncodeDecode(t *testing.T) {
+	prv, pub, err := GenerateKeyPairP256()
+	if err != nil {
+		t.Error(err)
+	}
+	privPEMEncoded := EncodePrivateKeyX509PEM(prv)
+	if privPEMEncoded == nil {
+		t.Error("failed to encode private key")
+	}
+
+	pubPEMEncoded := EncodePublicKeyX509PEM(pub)
+	if pubPEMEncoded == nil {
+		t.Error("failed to encode public key")
+	}
+
+	derPriv, err := DecodeX509PEM(privPEMEncoded)
+	if err != nil {
+		t.Error("failed to decode PEM block for private key")
+	}
+
+	derPub, err := DecodeX509PEM(pubPEMEncoded)
+	if err != nil {
+		t.Error("failed to decode pem block for public key")
+	}
+
+	// now unmarhsal the x509 serilaized keys an verify we have the same
+	prvKey, err := UnmarshalX509PrivateKey(derPriv)
+	if err != nil {
+		t.Error(err)
+	}
+	pubKey, err := UnmarshalPublicKeyX509(derPub)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(prv, prvKey) {
+		t.Error("private keys do not match")
+	}
+
+	if !reflect.DeepEqual(pub, pubKey) {
+		t.Error("public keys do not match")
+	}
+
+}

--- a/x509.go
+++ b/x509.go
@@ -1,0 +1,43 @@
+package crypto
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+)
+
+// MarhsalPrivateKeyX509 serialize a private key to DER-encoded format. (wrapper around x509 in crypto pkg )
+func MarhsalPrivateKeyX509(prvk *PrivateKey) ([]byte, error) {
+	x509EncodePubKey, err := x509.MarshalECPrivateKey(prvk.ToECDSA())
+	if err != nil {
+		return nil, err
+	}
+	return x509EncodePubKey, nil
+}
+
+// UnmarshalX509PrivateKey parses an ASN.1 Elliptic Curve Private Key Structure (wrapper around x509 in crypto pkg)
+func UnmarshalX509PrivateKey(der []byte) (*PrivateKey, error) {
+	key, err := x509.ParseECPrivateKey(der)
+	if err != nil {
+		return nil, err
+	}
+	return (*PrivateKey)(key), nil
+}
+
+// MarshaPublicKeyX509 serialize a public key to DER-encoded PKIX format. (wrapper around x509 in crypto pkg )
+func MarshaPublicKeyX509(pubk *PublicKey) ([]byte, error) {
+	x509EncodePubKey, err := x509.MarshalPKIXPublicKey(pubk.ToECDSA())
+	if err != nil {
+		return nil, err
+	}
+	return x509EncodePubKey, nil
+}
+
+// UnmarshalPublicKeyX509 parses a DER encoded public key. (wrapper around x509 in crypto pkg)
+func UnmarshalPublicKeyX509(der []byte) (*PublicKey, error) {
+	key, err := x509.ParsePKIXPublicKey(der)
+	eckey := key.(*ecdsa.PublicKey)
+	if err != nil {
+		return nil, err
+	}
+	return (*PublicKey)(eckey), nil
+}

--- a/x509_test.go
+++ b/x509_test.go
@@ -1,0 +1,38 @@
+package crypto
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMarshalling(t *testing.T) {
+	prv, pub, err := GenerateKeyPairP256()
+	if err != nil {
+		t.Error(err)
+	}
+	derPriv, err := MarhsalPrivateKeyX509(prv)
+	if err != nil {
+		t.Error(err)
+	}
+	derPub, err := MarshaPublicKeyX509(pub)
+	if err != nil {
+		t.Error(err)
+	}
+	// now unmarhsal the x509 serilaized keys an verify we have the same
+	prvKey, err := UnmarshalX509PrivateKey(derPriv)
+	if err != nil {
+		t.Error(err)
+	}
+	pubKey, err := UnmarshalPublicKeyX509(derPub)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(prv, prvKey) {
+		t.Error("private keys do not match")
+	}
+
+	if !reflect.DeepEqual(pub, pubKey) {
+		t.Error("public keys do not match")
+	}
+}


### PR DESCRIPTION
This was intended to replace the need to do manual serialization of  the public and private keys generated by ECDSA. 

Using X509 we can serialize both the private and public key into a DER byte slice. Then using the PEM encoding lib we can store the DER byte slice into a PEM file for both keys. 



