### PR TITLE
feat(address): Format functions added to Hash and Address

### DIFF
--- a/address.go
+++ b/address.go
@@ -1,5 +1,7 @@
 package crypto
 
+import "fmt"
+
 // AddressLength of address in bytes
 const (
 	AddressLength = 32
@@ -22,6 +24,12 @@ func (a Address) Hex() string {
 // String implements fmt.Stringer
 func (a Address) String() string {
 	return a.Hex()
+}
+
+// Format implements fmt.Formatter, forcing the byte slice to be formatted as is,
+// without going through the stringer interface used for logging.
+func (a Address) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "%"+string(c), a[:])
 }
 
 // SetBytes sets the hash to the value of b.

--- a/hash.go
+++ b/hash.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
 )
 
@@ -36,6 +37,12 @@ func encode(b []byte) string {
 // String implements fmt.Stringer
 func (h Hash) String() string {
 	return h.Hex()
+}
+
+// Format implements fmt.Formatter, forcing the byte slice to be formatted as is,
+// without going through the stringer interface used for logging.
+func (h Hash) Format(s fmt.State, c rune) {
+	fmt.Fprintf(s, "%"+string(c), h[:])
 }
 
 // HexToHash sets byte representation of s to hash.


### PR DESCRIPTION
## Description 

Adds Format methods to Address and Hash types to allow formatting as is for better readability.

### Impact 

This will allow the Address and Hash to be used in formatted output instead of defaulting to the stringer output.

## Steps to Test 
- None


## Feature Addressed 
- N/A


### Issue Address 
- N/A


### Release Info
- N/A

### Milestone 
- N/A