### PR TITLE
Address Change

### DIFF
--- a/address.go
+++ b/address.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // AddressLength of address in bytes
 const (
-	AddressLength = 32
+	AddressLength = 20
 )
 
 // Address represents a 32 byte address
@@ -50,7 +50,7 @@ func AddressFromPublicKey(pubk *PublicKey) (*Address, error) {
 	}
 	hashAddress := Sha3_256(x509encoded)
 	address := &Address{}
-	copy(address[AddressLength-len(hashAddress):], hashAddress)
+	address.SetBytes(hashAddress)
 	return address, nil
 }
 

--- a/address_test.go
+++ b/address_test.go
@@ -20,7 +20,7 @@ func TestAddress(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !reflect.DeepEqual(address, address2) {
-		t.Error("address do not match")
+	if !reflect.DeepEqual(*address, address2) {
+		t.Errorf("addresses do not match, eppected: [%v] got: [%v]", address, address2)
 	}
 }


### PR DESCRIPTION
## Description 

Changes the Address length from 32 bytes to 20 bytes.  This is to make the address conform to the EVM standard which is used by Solidity so that Solidity compiled bytecode can run without additional changes to the way addresses are stored.

### Impact 

12 bytes are dropped from the Sha when addresses are generated.  This makes the address slightly less secure from collision attacks, but conforms to the EVM standard to allow Solidity compiled bytecode to run.

## Steps to Test 
1. `go test` to run the unit tests.


## Feature Addressed 
- N/A

### Issue Address 
- N/A

### Release Info
- N/A

### Milestone 
- N/A 