### PR TITLE
Ed25519 length change to 64

### DIFF
--- a/ed25519.go
+++ b/ed25519.go
@@ -9,11 +9,11 @@ import (
 
 // There are two curves commonly used in the 25519 family, c25519 and ed25519,
 // they share some properties, for example the private and public key lengths.
-// in casses where a propertly refers to either one, I've attempted to use the
+// in casses where a propertly refers to either one use the
 // term x25519.
 const (
 	// X25519PrivateKeyLength Private key length for c25519 family of crypto primitives
-	X25519PrivateKeyLength = 32
+	X25519PrivateKeyLength = 64
 	// X25519PublicKeyLength Public key length for c25519 family of crypto primitives
 	X25519PublicKeyLength = 32
 	// X25519SignatureLength Signature length for c25519 family of crypto primitives
@@ -34,40 +34,32 @@ func NewEd25519Verifier(pubKey []byte) (Verifier, error) {
 // NewEd25519Signer constructor for ed25519 Signer
 func NewEd25519Signer(privKey []byte) (Signer, error) {
 	if len(privKey) != X25519PrivateKeyLength {
-		return nil, errors.New("key should be 32 bytes got " + fmt.Sprint(len(privKey)))
+		return nil, errors.New("key should be 64 bytes got " + fmt.Sprint(len(privKey)))
 	}
-	// The ed25519 library depends on a private key that includes the public
-	// and private key, so to get a private key you must pass a 32 byte private
-	// key to the FromSeed function.
-	key := ed25519.NewKeyFromSeed(privKey)
-	verifier, verErr := NewEd25519Verifier(key[32:])
+
+	verifier, verErr := NewEd25519Verifier(privKey[32:])
 	if verErr != nil {
 		return nil, verErr
 	}
+
 	return &ed25519Signer{
-		privKey:  key,
+		privKey:  privKey,
 		verifier: verifier,
 	}, nil
 }
 
 // GenerateEd25519KeyPair a valid Curve25519 key pair.
 func GenerateEd25519KeyPair() ([]byte, []byte, error) {
-	pubKey, privKey, genErr := ed25519.GenerateKey(nil)
-	// We take the first 32 bytes as the privKey as the private key. This is
-	// because the underlying crypto library returns a private key that is
-	// actually the private key with the public key appended to it.
-	return privKey[:32], pubKey, genErr
+	return ed25519.GenerateKey(nil)
 }
 
 // Ed25519PublicKeyFromPrivate return the public key associated with a private key for Curve25519.
 func Ed25519PublicKeyFromPrivate(privKey []byte) ([]byte, error) {
 	if len(privKey) != X25519PrivateKeyLength {
-		return nil, errors.New("key should be 32 bytes got " + fmt.Sprint(len(privKey)))
+		return nil, errors.New("key should be 64 bytes got " + fmt.Sprint(len(privKey)))
 	}
-
-	key := ed25519.NewKeyFromSeed(privKey)
-
-	return key[32:], nil
+	// last 32 bytes of the private key are the public key
+	return privKey[32:], nil
 }
 
 // ed25519Verifier Verifies a signature using Curve25519 and ed25519

--- a/ed25519_test.go
+++ b/ed25519_test.go
@@ -1,13 +1,12 @@
 package crypto
 
 import (
-	"crypto/ed25519"
 	"reflect"
 	"testing"
 )
 
 const Ed25519PubHex = "69ec35fafe61e514f4d2e54279671ab7e1e7fee9c4356da912ecd9f49db06773"
-const Ed25519PrivHex = "3a547668e859fb7b112a1e2dd7efcb739176ab8cfd1d9f224847fce362ebd99c"
+const Ed25519PrivHex = "3a547668e859fb7b112a1e2dd7efcb739176ab8cfd1d9f224847fce362ebd99c69ec35fafe61e514f4d2e54279671ab7e1e7fee9c4356da912ecd9f49db06773"
 const EdMessageHex = "91b5963ab438f4ddf9dbdda98d50eab56fb8dbab24242fd86997ed99d89f0869549ea309d697e6d072c479ff1464b4831c902e40b45e181df506b6cda5be36f95cd9023270e902e2ad7ce1c1e09545fc25733cd9d155f6c65bac93006ac9f9c6a2fcf912e5fbf49277d553576b9853900c906adde560"
 const EdSignatureHex = "b5aa14ad195fa99bcc1a0e77eb92903d6eb5fb387c3b71a3d19ac80ec86c1615251cc2ee0e06ba91319e5f56b893b03fb1160aa8dab4a72f69aa77be92d98d0c"
 
@@ -26,7 +25,7 @@ func TestEd25519Sign(t *testing.T) {
 	toSign, _ := FromHex(EdMessageHex)
 	privKey, _ := FromHex(Ed25519PrivHex)
 	signer := ed25519Signer{
-		privKey: ed25519.NewKeyFromSeed(privKey),
+		privKey: privKey,
 	}
 	signature, sigErr := signer.Sign(toSign)
 


### PR DESCRIPTION
fix: change crypto lib to largely be a common byte wrapper around golang crypto typedefs and keep private key length to 64 to avoid generate from seed form